### PR TITLE
Finetune LTE signal quality computation

### DIFF
--- a/tests/test_sig_quality.py
+++ b/tests/test_sig_quality.py
@@ -8,19 +8,19 @@ class TestLTE:
         q = SignalQuality_LTE._rsrq_to_q(0)
         assert(math.isclose(q, 1.0))
 
-        q = SignalQuality_LTE._rsrq_to_q(-7.999)
+        q = SignalQuality_LTE._rsrq_to_q(-6.999)
         assert(math.isclose(q, 1.0))
 
-        q = SignalQuality_LTE._rsrq_to_q(-8)
+        q = SignalQuality_LTE._rsrq_to_q(-7)
         assert(math.isclose(q, 1.0))
 
-        q = SignalQuality_LTE._rsrq_to_q(-11)
+        q = SignalQuality_LTE._rsrq_to_q(-10.25)
         assert(math.isclose(q, 0.775))
 
-        q = SignalQuality_LTE._rsrq_to_q(-14)
+        q = SignalQuality_LTE._rsrq_to_q(-13.5)
         assert(math.isclose(q, 0.55))
 
-        q = SignalQuality_LTE._rsrq_to_q(-17)
+        q = SignalQuality_LTE._rsrq_to_q(-16.75)
         assert(math.isclose(q, 0.325))
 
         q = SignalQuality_LTE._rsrq_to_q(-20)
@@ -62,7 +62,7 @@ class TestLTE:
 
     def test_1(self):
         # Excellent
-        lte_q = SignalQuality_LTE(-8, -80)
+        lte_q = SignalQuality_LTE(-7, -80)
         q = lte_q.quality()
         assert(math.isclose(q, 1.0))
 

--- a/vcuui/sig_quality.py
+++ b/vcuui/sig_quality.py
@@ -8,10 +8,13 @@ class SignalQuality_LTE:
         self._rsrp = rsrp
 
         q_rsrq = SignalQuality_LTE._rsrq_to_q(self._rsrq)
-        q_rsrp = SignalQuality_LTE._rsrp_to_q(self._rsrp)
+        # q_rsrp = SignalQuality_LTE._rsrp_to_q(self._rsrp)
+
+        # Use RSRQ only as quality indicator
+        self._quality = q_rsrq
 
         # Weigh RSRQ 2x and RSRP 1x
-        self._quality = (2.0 * q_rsrq + q_rsrp) / 3.0
+        # self._quality = (2.0 * q_rsrq + q_rsrp) / 3.0
 
     def quality(self):
         return self._quality
@@ -20,11 +23,11 @@ class SignalQuality_LTE:
     def _rsrq_to_q(cls, rsrq):
         """
         Maps LTE RSRQ to a 0..1 quality indicator
-        - >= -10: 1.0 Excellent
-        -  < -20: 0.2 Cell Edge
+        - >=  -7: 1.0 Excellent
+        -  < -20: 0.1 Cell Edge
         - Values in between are linear interpolated
         """
-        rsrq_high = -8
+        rsrq_high = -7
         rsrq_low = -20
         if rsrq > rsrq_high:
             q = cls.q_max
@@ -41,7 +44,7 @@ class SignalQuality_LTE:
         Maps LTE RSRP to a 0..1 quality indicator
 
         -  >= -80: 1.0 Excellent
-        -  < -100: 0.2 Cell Edge
+        -  < -100: 0.1 Cell Edge
         - Values in between are linear interpolated
         """
         rsrp_high = -80


### PR DESCRIPTION
- Base on RSRQ only
- Slightly raise bar for 100% (RSRQ = -7, formerly -8)